### PR TITLE
More app overflow issues

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2,21 +2,8 @@
   display: grid;
   grid-template-rows: min-content 1fr;
   grid-auto-flow: row;
-  height: 100vh;
-  overflow: hidden;
 }
 
-.main {
-  overflow-y: scroll;
-  height: 100%;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-}
-
-.content {
-  padding-bottom: 120px;
-}
 
 #legal_recomendations:hover {
   cursor: pointer;

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,31 +12,25 @@ import Project from './pages/project';
 import Profile from './components/Profile/Profile.component';
 import Footer from './components/footer';
 import './App.css';
-import './about.css';
 
 function App() {
   return (
     <Router>
-      <div className="App">
+      <main className="App">
         <Header />
-        <main className="main">
-          <div className="content">
-            <Switch>
-              <Route path="/" exact component={HomePage} />
-              <Route path="/about" exact component={AboutPage} />
-              <Route path="/search" exact component={SearchPage} />
-              <Route path="/signup" exact component={SignupPage} />
-              <Route path="/signup/volunteer" exact component={SignupVolunteerPage} />
-              <Route path="/projects/submit" exact component={ProjectSubmit} />
-              <Route path="/profile" exact component={Profile} />
-              <Route path="/style" exact component={Style} />
-              <Route path="/project" exact component={Project} />
-            </Switch>
-          </div>
-
-          <Footer />
-        </main>
-      </div>
+        <Switch>
+          <Route path="/" exact component={HomePage} />
+          <Route path="/about" exact component={AboutPage} />
+          <Route path="/search" exact component={SearchPage} />
+          <Route path="/signup" exact component={SignupPage} />
+          <Route path="/signup/volunteer" exact component={SignupVolunteerPage} />
+          <Route path="/projects/submit" exact component={ProjectSubmit} />
+          <Route path="/profile" exact component={Profile} />
+          <Route path="/style" exact component={Style} />
+          <Route path="/project" exact component={Project} />
+        </Switch>
+        <Footer />
+      </main>
     </Router>
   );
 }

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import {
-  Grid, Paper, Typography, Button, Hidden, Dialog,
+  Grid, Typography, Button, Hidden, Dialog,
 } from '@material-ui/core';
 import ExitToAppIcon from '@material-ui/icons/ExitToApp';
 import { makeStyles } from '@material-ui/core/styles';

--- a/frontend/src/css/about.css
+++ b/frontend/src/css/about.css
@@ -8,7 +8,7 @@
 
 .heroAbout {
   position: absolute;
-  background-image: url("./images/hero-edit.png");
+  background-image: url("../images/hero-edit.png");
   background-size: cover;
   background-repeat: no-repeat;
   top: 0;

--- a/frontend/src/pages/about.jsx
+++ b/frontend/src/pages/about.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import {
   Typography,
 } from '@material-ui/core';
-
 import AboutImg from '../images/about.png';
+import '../css/about.css';
 
 const AboutPage = () => (
   <div>

--- a/frontend/src/pages/home.jsx
+++ b/frontend/src/pages/home.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   Typography,
 } from '@material-ui/core';
+import '../css/about.css';
 
 import AboutImg from '../images/about.png';
 


### PR DESCRIPTION
*  Put `about.css` in the about page not in the homepage
* We've lots or magic numbers and repeated css properties in `main` and `content`. We don't need them this high in the css tree.
* Removing the above stops the app having weird alignment issues on the homepage and a scroll bar within a scroll bar. Like so 👇 
![image](https://user-images.githubusercontent.com/16007179/77580369-cc1f9c80-6ed3-11ea-86c7-b9dacd299415.png)
