### PR TITLE
Search Output Visibility Fix

### DIFF
--- a/frontend/src/components/Search/MobileSearch.jsx
+++ b/frontend/src/components/Search/MobileSearch.jsx
@@ -58,7 +58,8 @@ const useStyles = makeStyles((theme) => ({
     position: 'absolute',
     left: 0,
     top: 50,
-    transition: theme.transitions.create(['width', 'left', 'opacity'], {
+    visibility: 'hidden',
+    transition: theme.transitions.create(['width', 'left', 'opacity', 'visibility'], {
       easing: theme.transitions.easing.easeIn,
       duration: theme.transitions.duration.enteringScreen,
     }),
@@ -66,7 +67,8 @@ const useStyles = makeStyles((theme) => ({
   show: {
     zIndex: 1,
     opacity: 1,
-    transition: theme.transitions.create(['width', 'left', 'opacity'], {
+    visibility: 'visible',
+    transition: theme.transitions.create(['width', 'left', 'opacity', 'visibility'], {
       easing: theme.transitions.easing.easeIn,
       duration: theme.transitions.duration.enteringScreen,
     }),


### PR DESCRIPTION
Search output previously wasn't hiding properly and was preventing clicking/highlighting of any elements underneath where it's located. Here's the fix.